### PR TITLE
Add proposal generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Expense Proposal Generator
+
+This repository now includes a small script to generate a Korean "품의서" (proposal) based on information contained in a "지출결의서" PDF.
+
+## Requirements
+
+- Python 3.8+
+- `pdfplumber`
+- `jinja2`
+
+Install dependencies with:
+
+```bash
+pip install pdfplumber jinja2
+```
+
+## Usage
+
+```
+python scripts/generate_proposal.py expense.pdf output.html
+```
+
+The script extracts key fields from `expense.pdf` and writes an HTML proposal to `output.html` using `templates/proposal_template.html`.
+
+Customize the regular expressions in `scripts/generate_proposal.py` if your PDF format differs.

--- a/scripts/generate_proposal.py
+++ b/scripts/generate_proposal.py
@@ -1,0 +1,76 @@
+import re
+import sys
+from pathlib import Path
+
+import pdfplumber
+from jinja2 import Environment, FileSystemLoader
+
+
+def parse_expense_pdf(pdf_path):
+    """Parse expense data from a given pdf file.
+
+    Parameters
+    ----------
+    pdf_path : str or Path
+        Path to the expense settlement pdf.
+
+    Returns
+    -------
+    dict
+        Parsed information with keys like 'gwan', 'hang', 'mok',
+        'account', 'description', 'amount', and 'vendor'.
+    """
+    result = {
+        "gwan": None,
+        "hang": None,
+        "mok": None,
+        "account": None,
+        "description": None,
+        "amount": None,
+        "vendor": None,
+    }
+
+    with pdfplumber.open(pdf_path) as pdf:
+        text = "\n".join(page.extract_text() for page in pdf.pages if page.extract_text())
+
+    # Simple regex based extraction. Adjust patterns according to actual pdf.
+    patterns = {
+        "gwan": r"관[:\s]*([^\n]+)",
+        "hang": r"항[:\s]*([^\n]+)",
+        "mok": r"목[:\s]*([^\n]+)",
+        "account": r"계정과목[\(세목\)]*[:\s]*([^\n]+)",
+        "description": r"적요[:\s]*([^\n]+)",
+        "amount": r"금액[:\s]*([\d,]+)",
+        "vendor": r"거래처[:\s]*([^\n]+)",
+    }
+
+    for key, pattern in patterns.items():
+        match = re.search(pattern, text)
+        if match:
+            result[key] = match.group(1).strip()
+
+    return result
+
+
+def render_template(data, output_path):
+    env = Environment(loader=FileSystemLoader("templates"))
+    template = env.get_template("proposal_template.html")
+    rendered = template.render(**data)
+    Path(output_path).write_text(rendered, encoding="utf-8")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python generate_proposal.py <input.pdf> <output.html>")
+        sys.exit(1)
+
+    pdf_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    data = parse_expense_pdf(pdf_path)
+    render_template(data, output_path)
+    print(f"Proposal saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/proposal_template.html
+++ b/templates/proposal_template.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>품의서</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em; }
+        table { width: 100%; border-collapse: collapse; }
+        td, th { border: 1px solid #999; padding: 0.5em; }
+        th { background: #eee; }
+    </style>
+</head>
+<body>
+    <h1>품의서</h1>
+    <table>
+        <tr><th>관</th><td>{{ gwan }}</td></tr>
+        <tr><th>항</th><td>{{ hang }}</td></tr>
+        <tr><th>목</th><td>{{ mok }}</td></tr>
+        <tr><th>계정과목(세목)</th><td>{{ account }}</td></tr>
+        <tr><th>적요</th><td>{{ description }}</td></tr>
+        <tr><th>금액</th><td>{{ amount }}</td></tr>
+        <tr><th>거래처</th><td>{{ vendor }}</td></tr>
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add instructions for generating a proposal from an expense PDF
- implement `generate_proposal.py` script
- add HTML template for proposals

## Testing
- `python3 scripts/generate_proposal.py` *(fails: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_6866032e5dd4832aae9bdec38af3997e